### PR TITLE
Updated open function

### DIFF
--- a/automator.py
+++ b/automator.py
@@ -39,7 +39,7 @@ print("**********************************************************")
 print("**********************************************************")
 print(style.RESET)
 
-f = open("message.txt", "r")
+f = open("message.txt", "r", encoding="utf8")
 message = f.read()
 f.close()
 


### PR DESCRIPTION
Explicitly specified the encoding to be utf-8 so that emojis can also be parsed and sent properly in the message. For instance-

1. 😡😡😡 are not parsed properly
2. 😡😡😡❤️🖤💛 throws UnicodeDecodeError.