### PR TITLE
Update requirements.txt (broken due to webdriver-manager version)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 selenium==3.141.0
-webdriver-manager==3.4.2
+webdriver-manager


### PR DESCRIPTION

The web driver in webdriver-manager library 3.4.2 version is not supported anymore and the drivers are updated on need-based so it's best for it to be updated.